### PR TITLE
Remove deprecated version input

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Defaults to `false` instead of `true`
 
 Defaults to `env.NODE_VERSION` instead of `undefined`
 
+### Removes deprecated `version` from `actions/setup-node`
+
+This property is removed to prevent warnings in action runs. Use `node-version` instead.
+
 ### `useRollingCache` from `bahmutov/npm-install`
 
 Defaults to `true` instead of `false`

--- a/action.yml
+++ b/action.yml
@@ -132,10 +132,6 @@ inputs:
   cache-dependency-path:
     description: 'Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies.'
     required: false
-  version:
-    description: 'Deprecated. Use node-version instead. Will not be supported after October 1, 2019'
-    deprecationMessage: 'The version property will not be supported after October 1, 2019. Use node-version instead'
-    required: false
 
   ###############################################################
   ############ Inputs from bahmutov/npm-install@v1 ##############


### PR DESCRIPTION
The `version` property is removed to prevent warnings in action runs. Use `node-version` instead.